### PR TITLE
15/04/2022 Phat merges

### DIFF
--- a/app/src/main/java/com/example/warehousemanagement/AddProductActivity.java
+++ b/app/src/main/java/com/example/warehousemanagement/AddProductActivity.java
@@ -110,7 +110,7 @@ public class AddProductActivity extends AppCompatActivity implements Edit_Delete
         etId = findViewById(R.id.editTextProductId);
 
         lyOption = findViewById(R.id.lyOption);
-        btnSave = findViewById(R.id.btnSave);
+        btnSave = findViewById(R.id.btnOK);
         btnCancel = findViewById(R.id.btnCancel);
 
         tvTitle = findViewById(R.id.tvTitle);

--- a/app/src/main/java/com/example/warehousemanagement/AddWarehouseActivity.java
+++ b/app/src/main/java/com/example/warehousemanagement/AddWarehouseActivity.java
@@ -56,7 +56,7 @@ public class AddWarehouseActivity extends AppCompatActivity {
         etId = findViewById(R.id.etId);
 
         lyOption = findViewById(R.id.lyOption);
-        btnSave = findViewById(R.id.btnSave);
+        btnSave = findViewById(R.id.btnOK);
         btnCancel = findViewById(R.id.btnCancel);
     }
 

--- a/app/src/main/java/com/example/warehousemanagement/EditReceiptDetailActivity.java
+++ b/app/src/main/java/com/example/warehousemanagement/EditReceiptDetailActivity.java
@@ -86,7 +86,7 @@ public class EditReceiptDetailActivity extends AppCompatActivity implements Cust
         btnDelete = findViewById(R.id.btnDelete);
         etQuantity = findViewById(R.id.etQuantity);
         etUnit = findViewById(R.id.etUnit);
-        btnSave = findViewById(R.id.btnSave);
+        btnSave = findViewById(R.id.btnOK);
         btnCancel = findViewById(R.id.btnCancel);
         tvProductId = findViewById(R.id.tvProductId);
         tvProductName = findViewById(R.id.tvProductName);

--- a/app/src/main/java/com/example/warehousemanagement/ProductDetailActivity.java
+++ b/app/src/main/java/com/example/warehousemanagement/ProductDetailActivity.java
@@ -105,7 +105,7 @@ public class ProductDetailActivity extends AppCompatActivity {
         etId = findViewById(R.id.etId);
 
         lyOption = findViewById(R.id.lyOption);
-        btnSave = findViewById(R.id.btnSave);
+        btnSave = findViewById(R.id.btnOK);
         btnCancel = findViewById(R.id.btnCancel);
     }
 

--- a/app/src/main/java/com/example/warehousemanagement/WarehouseDetailActivity.java
+++ b/app/src/main/java/com/example/warehousemanagement/WarehouseDetailActivity.java
@@ -17,7 +17,6 @@ import androidx.appcompat.app.AlertDialog;
 import androidx.appcompat.app.AppCompatActivity;
 
 import com.example.warehousemanagement.dao.WarehouseDao;
-import com.example.warehousemanagement.dialog.CustomDialog;
 import com.example.warehousemanagement.model.Warehouse;
 
 public class WarehouseDetailActivity extends AppCompatActivity {
@@ -101,7 +100,7 @@ public class WarehouseDetailActivity extends AppCompatActivity {
         etId = findViewById(R.id.etId);
 
         lyOption = findViewById(R.id.lyOption);
-        btnSave = findViewById(R.id.btnSave);
+        btnSave = findViewById(R.id.btnOK);
         btnCancel = findViewById(R.id.btnCancel);
     }
 

--- a/app/src/main/java/com/example/warehousemanagement/dialog/SortOptionDialog.java
+++ b/app/src/main/java/com/example/warehousemanagement/dialog/SortOptionDialog.java
@@ -37,8 +37,8 @@ public class SortOptionDialog extends BottomSheetDialogFragment {
         if (sortOptionFor.equalsIgnoreCase("receipt")) {
             view1 = inflater.inflate(R.layout.dialog_sort_by_option_for_receipt, container, false);
 
-            Button btnXacNhan = (Button) view1.findViewById(R.id.btnXacNhan);
-            Button btnHuy = (Button) view1.findViewById(R.id.btnHuy);
+            Button btnXacNhan = (Button) view1.findViewById(R.id.btnOK);
+            Button btnHuy = (Button) view1.findViewById(R.id.btnCancel);
             RadioButton rBTangDan = (RadioButton) view1.findViewById(R.id.radioBtnTangDan);
             RadioButton rBGiamDan = (RadioButton) view1.findViewById(R.id.radioBtnGiamDan);
 
@@ -200,5 +200,10 @@ public class SortOptionDialog extends BottomSheetDialogFragment {
 
     public interface SortOptionDialogListener {
         void setSortOption(String sortOption);
+    }
+
+    @Override
+    public int getTheme() {
+        return R.style.BottomSheetDialogTheme;
     }
 }

--- a/app/src/main/res/color/radio_button_color.xml
+++ b/app/src/main/res/color/radio_button_color.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+<!--    <item android:color="@color/space_cadet" android:state_selected="true" />-->
+    <item android:color="@color/space_cadet" android:state_checked="true" />
+    <item android:color="@color/space_cadet" android:state_checked="false" />
+<!--    <item android:color="@color/azureish_white" android:state_enabled="false" />-->
+<!--    <item android:color="@color/steel_blue" android:state_enabled="true" />-->
+</selector>

--- a/app/src/main/res/drawable-xxhdpi/bg_culture_top_radius_25.xml
+++ b/app/src/main/res/drawable-xxhdpi/bg_culture_top_radius_25.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="@color/cultured" />
+    <corners android:topRightRadius="25dp" android:topLeftRadius="25dp" />
+</shape>

--- a/app/src/main/res/drawable/border_bottom.xml
+++ b/app/src/main/res/drawable/border_bottom.xml
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android" >
-    <item>
-        <shape
-            android:shape="rectangle">
-            <stroke android:width="1dp" android:color="#221A1A" />
-            <solid android:color="#fff" />
+<!--    <item>-->
+<!--        <shape-->
+<!--            android:shape="rectangle">-->
+<!--            <stroke android:width="1dp" android:color="#221A1A" />-->
+<!--            <solid android:color="#fff" />-->
 
-        </shape>
-    </item>
-    <!--android:top="1dp"-->
-    <item android:bottom="1dp">
-        <shape
-            android:shape="rectangle">
-            <stroke android:width="1dp" android:color="#FFFFFF" />
-            <solid android:color="#00000000" />
+<!--        </shape>-->
+<!--    </item>-->
+<!--    &lt;!&ndash;android:top="1dp"&ndash;&gt;-->
+<!--    <item android:bottom="1dp">-->
+<!--        <shape-->
+<!--            android:shape="rectangle">-->
+<!--            <stroke android:width="1dp" android:color="#FFFFFF" />-->
+<!--            <solid android:color="#00000000" />-->
+<!--        </shape>-->
+<!--    </item>-->
+
+    <item android:gravity="bottom">
+        <shape>
+            <size android:height="1dp" />
+            <solid android:color="@color/azureish_white" />
         </shape>
     </item>
 

--- a/app/src/main/res/layout/activity_edit_warehouse.xml
+++ b/app/src/main/res/layout/activity_edit_warehouse.xml
@@ -129,7 +129,7 @@
         app:layout_constraintTop_toBottomOf="@id/constraintLayout4">
 
         <include
-            layout="@layout/group_button_save_cancel"
+            layout="@layout/group_button_ok_cancel"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/dialog_sort_by_option_for_receipt.xml
+++ b/app/src/main/res/layout/dialog_sort_by_option_for_receipt.xml
@@ -1,128 +1,73 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:orientation="vertical"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    style="@style/Theme.WarehouseManagement"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
-    <LinearLayout
+    android:layout_height="match_parent"
+    android:background="@drawable/bg_culture_top_radius_25"
+    android:orientation="vertical"
+    android:padding="21dp">
+
+
+    <include
+        layout="@layout/group_sort_order_radio_button"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+
+    <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="vertical"
-        android:padding="20dp"
-        tools:ignore="MissingConstraints">
+        android:layout_marginTop="30dp"
+        android:layout_marginBottom="10dp"
+        android:text="Sắp xếp theo?"
+        android:textColor="@color/steel_blue"
+        android:textSize="24sp"
+        android:textStyle="bold" />
 
-        <TextView
+    <RadioGroup
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content">
+
+        <RadioButton
+            android:id="@+id/radioBtnTheoMa"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Thứ tự"
-            android:textSize="24dp"
-            android:textStyle="bold"
-            android:layout_marginBottom="20dp"
-            />
+            android:background="@drawable/border_bottom"
+            android:buttonTint="@color/radio_button_color"
+            android:checked="true"
+            android:fontFamily="@font/roboto_regular"
+            android:padding="10dp"
+            android:text="Mã phiếu"
+            android:textColor="@color/space_cadet"
+            android:textSize="18sp" />
 
-        <LinearLayout
+        <RadioButton
+            android:id="@+id/radioBtnTheoNgay"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:orientation="horizontal">
-            <RadioGroup
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:orientation="horizontal">
-                <RadioButton
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:paddingVertical="12dp"
-                    android:checked="true"
-                    android:layout_weight="1"
-                    android:textSize="20dp"
-                    android:background="@drawable/border_bottom"
-                    android:text="Tăng dần"
-                    android:id="@+id/radioBtnTangDan"/>
-                <RadioButton
-                    android:layout_width="wrap_content"
-                    android:layout_height="wrap_content"
-                    android:layout_weight="1"
+            android:background="@drawable/border_bottom"
+            android:buttonTint="@color/radio_button_color"
+            android:fontFamily="@font/roboto_regular"
+            android:padding="10dp"
+            android:text="Ngày lập phiếu"
+            android:textColor="@color/space_cadet"
+            android:textSize="18sp" />
 
-                    android:paddingVertical="12dp"
-                    android:textSize="20dp"
-                    android:background="@drawable/border_bottom"
-                    android:text="Giảm dần"
-                    android:id="@+id/radioBtnGiamDan"/>
-            </RadioGroup>
-        </LinearLayout>
-        <TextView
+        <RadioButton
+            android:id="@+id/radioBtnTheoSoLuong"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:text="Sắp xếp theo?"
-            android:textSize="24dp"
-            android:textStyle="bold"
-            android:layout_marginVertical="20dp"
-            />
-        <RadioGroup
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content">
-            <RadioButton
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Mã phiếu"
-                android:textSize="20dp"
-                android:paddingHorizontal="16dp"
-                android:paddingVertical="12dp"
-                android:background="@drawable/border_bottom"
-                android:checked="true"
-                android:id="@+id/radioBtnTheoMa"
-                />
-            <RadioButton
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Ngày lập phiếu"
-                android:textSize="20dp"
-                android:paddingHorizontal="16dp"
-                android:paddingVertical="12dp"
-                android:background="@drawable/border_bottom"
-                android:id="@+id/radioBtnTheoNgay"
-                />
-            <RadioButton
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="Số loại vật tư trong phiếu"
-                android:textSize="20dp"
-                android:paddingHorizontal="16dp"
-                android:paddingVertical="12dp"
-                android:background="@drawable/border_bottom"
-                android:id="@+id/radioBtnTheoSoLuong"
+            android:buttonTint="@color/radio_button_color"
+            android:fontFamily="@font/roboto_regular"
+            android:padding="10dp"
+            android:text="Số loại vật tư trong phiếu"
+            android:textColor="@color/space_cadet"
+            android:textSize="18sp" />
+    </RadioGroup>
 
-                />
-        </RadioGroup>
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal">
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_weight="1"
-                android:background="@drawable/bg_azureich_white_radius_25"
-                android:text="Hủy"
-                android:textSize="20dp"
-                android:id="@+id/btnHuy"
-                android:textColor="@color/black"
-                android:layout_marginRight="20dp"
-                android:textStyle="bold"/>
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:layout_marginTop="20dp"
-                android:layout_weight="1"
-                android:background="@drawable/bg_steel_blue_radius_15"
-                android:text="Sắp xếp"
-                android:textSize="20dp"
-                android:id="@+id/btnXacNhan"
-                android:textColor="@color/white"
-                android:textStyle="bold"/>
-        </LinearLayout>
-
-
-    </LinearLayout>
-</RelativeLayout>
+    <include
+        layout="@layout/group_button_ok_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="40dp" />
+</LinearLayout>

--- a/app/src/main/res/layout/group_button_ok_cancel.xml
+++ b/app/src/main/res/layout/group_button_ok_cancel.xml
@@ -3,17 +3,16 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:gravity="center_horizontal"
-    android:orientation="horizontal"
-    android:paddingVertical="10dp">
+    android:orientation="horizontal">
 
     <Button
-        android:id="@+id/btnSave"
+        android:id="@+id/btnOK"
         android:layout_width="140dp"
         android:layout_height="wrap_content"
         android:layout_marginEnd="40dp"
-        android:background="@drawable/bg_steel_blue_radius_15"
+        android:background="@drawable/bg_space_cadet_radius_15"
         android:fontFamily="@font/roboto_medium"
-        android:text="Lưu"
+        android:text="OK"
         android:textAllCaps="false"
         android:textColor="@color/cultured"
         android:textSize="20sp" />
@@ -26,7 +25,7 @@
         android:fontFamily="@font/roboto_medium"
         android:text="Hủy"
         android:textAllCaps="false"
-        android:textColor="@color/steel_blue"
+        android:textColor="@color/space_cadet"
         android:textSize="20sp" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/group_sort_order_radio_button.xml
+++ b/app/src/main/res/layout/group_sort_order_radio_button.xml
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="10dp"
+        android:text="Thứ tự"
+        android:textColor="@color/steel_blue"
+        android:textSize="24sp"
+        android:textStyle="bold" />
+
+    <RadioGroup
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="@android:color/transparent"
+        android:orientation="horizontal">
+
+        <RadioButton
+            android:id="@+id/radioBtnTangDan"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:buttonTint="@color/radio_button_color"
+            android:checked="true"
+            android:padding="10dp"
+            android:shadowRadius="0"
+            android:text="Tăng dần"
+            android:textColor="@color/space_cadet"
+            android:textSize="18sp" />
+
+        <RadioButton
+            android:id="@+id/radioBtnGiamDan"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:buttonTint="@color/radio_button_color"
+            android:padding="10dp"
+            android:text="Giảm dần"
+            android:textColor="@color/space_cadet"
+            android:textSize="18sp" />
+    </RadioGroup>
+
+</LinearLayout>

--- a/app/src/main/res/layout/product_add_activity.xml
+++ b/app/src/main/res/layout/product_add_activity.xml
@@ -218,7 +218,7 @@
             app:layout_constraintTop_toBottomOf="@id/constraintLayout4">
 
             <include
-                layout="@layout/group_button_save_cancel"
+                layout="@layout/group_button_ok_cancel"
                 app:layout_constraintBottom_toBottomOf="parent"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/product_add_activity_linear.xml
+++ b/app/src/main/res/layout/product_add_activity_linear.xml
@@ -201,7 +201,7 @@
                 android:layout_height="1dp"
                 android:layout_weight="1" />
 
-            <include layout="@layout/group_button_save_cancel" />
+            <include layout="@layout/group_button_ok_cancel" />
         </LinearLayout>
     </ScrollView>
 </LinearLayout>

--- a/app/src/main/res/layout/receipt_detail_edit_activity.xml
+++ b/app/src/main/res/layout/receipt_detail_edit_activity.xml
@@ -135,7 +135,7 @@
 
     <include
         android:id="@+id/constraintLayout5"
-        layout="@layout/group_button_save_cancel"
+        layout="@layout/group_button_ok_cancel"
         android:layout_width="match_parent"
         android:layout_height="wrap_content" />
 

--- a/app/src/main/res/layout/warehouse_add_activity.xml
+++ b/app/src/main/res/layout/warehouse_add_activity.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
@@ -86,7 +85,7 @@
             android:paddingHorizontal="20dp"
             android:textAlignment="textStart"
             android:textColor="@color/space_cadet"
-            android:textColorHint="@color/steel_blue"/>
+            android:textColorHint="@color/steel_blue" />
     </LinearLayout>
 
     <LinearLayout
@@ -117,10 +116,12 @@
             android:paddingHorizontal="20dp"
             android:textAlignment="textStart"
             android:textColor="@color/space_cadet"
-            android:textColorHint="@color/steel_blue"/>
+            android:textColorHint="@color/steel_blue" />
     </LinearLayout>
 
     <include
-        layout="@layout/group_button_save_cancel" />
+        layout="@layout/group_button_ok_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/warehouse_detail_activity.xml
+++ b/app/src/main/res/layout/warehouse_detail_activity.xml
@@ -165,6 +165,6 @@
 
 
     <include
-        layout="@layout/group_button_save_cancel" />
+        layout="@layout/group_button_ok_cancel" />
 
 </LinearLayout>


### PR DESCRIPTION
Redesign the dialog_sort_for_receipt:

+ Remove the parent Relative Layout. Set the background to bg_culture_top_radius_25. Set the parent padding to 21dp

+ Create file radio_button_color.xml to custom radio button color, modify the border_bottom.xml.

+ Separate the sort_by_order code to group_sort_order_radio_button.xml file  

+ Remove the buttongroup at the bottom of the layout, include from group_button_ok_cancel instead

+ Change the id to btnOK and btnCancel